### PR TITLE
refactor(serve): add a more useful error message when yaml can't be read

### DIFF
--- a/src/commands/serve/handler.spec.ts
+++ b/src/commands/serve/handler.spec.ts
@@ -92,6 +92,18 @@ describe('handler', () => {
       expect(mockReadYamlAsync).toBeCalledWith(resolvedPath)
     })
 
+    it('throws a useful error when readYamlAsync fails', async () => {
+      mockReadYamlAsync.mockRejectedValue(new Error('that aint right'))
+
+      await handler(args)
+
+      expect(mockHandleError).toBeCalledWith(
+        expect.objectContaining({
+          message: 'Problem reading your config file: that aint right',
+        }),
+      )
+    })
+
     it('calls validate with the correct args', async () => {
       const rawConfigs: unknown[] = [{ name: 'My Raw Config' }]
       mockReadYamlAsync.mockResolvedValue(rawConfigs)

--- a/src/commands/serve/handler.ts
+++ b/src/commands/serve/handler.ts
@@ -80,7 +80,15 @@ const createHandler = (
   }
 
   const prepAndStartServer = async (): Promise<PrepAndStartResult> => {
-    const validationResult = validate(await readYamlAsync(absoluteConfigPath))
+    let rawConfigFile: unknown
+
+    try {
+      rawConfigFile = await readYamlAsync(absoluteConfigPath)
+    } catch (err) {
+      throw new Error(`Problem reading your config file: ${err.message}`)
+    }
+
+    const validationResult = validate(rawConfigFile)
     if (!validationResult.success) {
       throw new Error(`${CONFIG_ERROR_PREFIX}${validationResult.errors.join('\n')}`)
     }


### PR DESCRIPTION
Added a bit of context to the resulting error message in the case that reading the yaml file fails