### PR TITLE
fix(server): fix bizarre duplicate logs

### DIFF
--- a/src/commands/serve/server/index.ts
+++ b/src/commands/serve/server/index.ts
@@ -84,23 +84,8 @@ export const configureServer = (
           serverLogger.warn(
             `An endpoint for ${req.path} exists but the query params did not match the configuration`,
           )
-          next()
+          return next()
         }
-
-        // TODO ======= finish up by adding tests. maybe extract it out
-        // const actualQuery = parse(req.url, true).query
-        // const expectedQuery = parse(request.endpoint, true).query
-
-        // const queryMismatches = Object.keys(expectedQuery)
-        //   .map((key) => isQueryMismatch(key, expectedQuery[key], actualQuery[key]))
-        //   .filter((x): x is string => !!x)
-
-        // if (queryMismatches.length) {
-        //   res.locals.message = queryMismatches.join('\n')
-        //   res.locals.status = 400
-        //   return next()
-        // }
-        // ============================================
 
         if (typeValidator && request.type) {
           const problems = await typeValidator.getProblems(req.body, request.type, ProblemType.Request)

--- a/src/commands/serve/server/server.integration.spec.ts
+++ b/src/commands/serve/server/server.integration.spec.ts
@@ -122,7 +122,7 @@ describe('server', () => {
   })
 
   describe('request query strings', () => {
-    it('gives a 200 when a query matches in a different order', async () => {
+    it('still responds when a query matches in a different order', async () => {
       const configs = [
         new ConfigBuilder().withEndpoint('/api/resource?greetings=hello&greetings=bye').build(),
       ]
@@ -132,7 +132,27 @@ describe('server', () => {
       await request(app).get('/api/resource?greetings=bye&greetings=hello').expect(200)
     })
 
-    it('gives a 404 if a query does not match', async () => {
+    it('responds when a query matches a different config', async () => {
+      const configs = [
+        new ConfigBuilder()
+          .withName('Config1')
+          .withEndpoint('/api/resource?greetings=hello&greetings=bye')
+          .withResponseBody('nope')
+          .build(),
+        new ConfigBuilder()
+          .withName('Config2')
+          .withEndpoint('/api/resource?greetings=hi&greetings=bye')
+          .withResponseCode(202)
+          .withResponseBody('YES')
+          .build(),
+      ]
+
+      const app = configureServer('example.com', configs)
+
+      await request(app).get('/api/resource?greetings=hi&greetings=bye').expect(202).expect('YES')
+    })
+
+    it('gives a 404 if a query does not match any config', async () => {
       const configs = [
         new ConfigBuilder().withEndpoint('/api/resource?greetings=hello&greetings=bye').build(),
       ]


### PR DESCRIPTION
I forgot to return after doing the query validation, so even if the query was found to be invalid it
would still continue trying to serve the request using the same handler

re #50