### PR TITLE
fix(serve): fix config errors not being separated claerly in output

### DIFF
--- a/src/commands/serve/handler.spec.ts
+++ b/src/commands/serve/handler.spec.ts
@@ -6,6 +6,7 @@ import { readYamlAsync } from '~io'
 import { ValidationSuccess, validate, transformConfigs, ValidatedServeConfig, Config } from './config'
 import { resolve } from 'path'
 import chokidar, { FSWatcher } from 'chokidar'
+import stripAnsi from 'strip-ansi'
 
 jest.unmock('./handler')
 jest.unmock('@hapi/joi')
@@ -244,14 +245,14 @@ describe('handler', () => {
 
         await handler(args)
 
-        const errLine1 = `Config '${transformedConfig.name}' request body failed type validation:\n${error1}\n${error2}`
-        const errLine2 = `Config '${transformedConfig.name}' response body failed type validation:\n${error3}`
+        const errPart1 = 'Could not start serving due to config errors:'
+        const errPart2 = `Config '${transformedConfig.name}' request body failed type validation:\n${error1}\n${error2}`
+        const errPart3 = `Config '${transformedConfig.name}' response body failed type validation:\n${error3}`
 
         expect(mockHandleError).toBeCalled()
-        expect(mockHandleError.mock.calls[0][0].message).toContain(
-          'Could not start serving due to config errors:',
+        expect(stripAnsi(mockHandleError.mock.calls[0][0].message)).toEqual(
+          `${errPart1}\n\n${errPart2}\n${errPart3}`,
         )
-        expect(mockHandleError.mock.calls[0][0].message).toContain(`\n\n${errLine1}\n${errLine2}`)
       })
     })
 

--- a/src/commands/serve/handler.ts
+++ b/src/commands/serve/handler.ts
@@ -32,7 +32,7 @@ const validateConfigBodies = async (
     return true
   })
 
-  let totalValidationError = ''
+  const totalValidationErrors: string[] = []
   for (const config of uniqueConfigs) {
     const validationErrors: string[] = []
 
@@ -55,10 +55,10 @@ const validateConfigBodies = async (
       }
     }
 
-    totalValidationError += validationErrors.join('\n')
+    if (validationErrors.length) totalValidationErrors.push(validationErrors.join('\n'))
   }
 
-  if (totalValidationError) return CONFIG_ERROR_PREFIX + totalValidationError
+  if (totalValidationErrors.length) return CONFIG_ERROR_PREFIX + totalValidationErrors.join('\n\n')
 }
 
 const createHandler = (


### PR DESCRIPTION
fix #128