### PR TITLE
feat(serve): allow serveEndpoints to allow wildcard query params

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -84,7 +84,8 @@ Here's a format that describes each config setting:
   # Or...
   endpoints:
     - /my/endpoint1
-    - /my/endpoint2?hello=world # only served if request has query param "hello" with value "world"
+    # only served if request has query param "hello" with value "world"
+    - /my/endpoint2?hello=world 
   ```
 
 ### request.serveEndpoint
@@ -94,13 +95,23 @@ Here's a format that describes each config setting:
   ([read more](https://expressjs.com/en/guide/routing.html#route-paths)).
   Regex is not yet supported.<br>
   This property is ignored in Test mode.
-  In Serve Mode, your config will be served on the `request.endpoints`
-  and also this endpoint.
+  In Serve Mode, your config will be served on each specified endpoint of 
+  `request.endpoints` and also this endpoint.
 - **Type**: string
 - **Required?**: Required in Serve mode if `request.endpoints` is not provided
 - **Example**:
   ```yaml
+  # will serve any endpoints starting with /api/books/
   serveEndpoint: /api/books/*
+  
+  # to require a query string with key 'hello' and value 'world'
+  serveEndpoint: /api/books/book1?hello=world
+  
+  # to require a query string with key 'hello' set to any value (*)
+  serveEndpoint: /api/books/book1?hello=*
+  
+  # to require multiple query params
+  serveEndpoint: /api/books/book1?hello=world&something=*&spongebob=squarepants
   ```
 
 ### request.method

--- a/src/commands/serve/server/query-validator.spec.ts
+++ b/src/commands/serve/server/query-validator.spec.ts
@@ -1,4 +1,5 @@
 import validateQuery from './query-validator'
+import { randomString } from '~test-helpers'
 
 jest.unmock('./query-validator')
 jest.unmock('qs')
@@ -89,4 +90,20 @@ it('returns false if an object does not match deeply', () => {
   const isValid = validateQuery(endpoint, requestQuery)
 
   expect(isValid).toBe(false)
+})
+
+describe('wildcard queries', () => {
+  it('returns true for any value', () => {
+    const endpoint = '/api/resource?hello=*'
+    const query = { hello: randomString() }
+
+    expect(validateQuery(endpoint, query)).toBe(true)
+  })
+
+  it('returns true for an array of any values', () => {
+    const endpoint = '/api/resource?hello=*'
+    const query = { hello: [randomString(), randomString()] }
+
+    expect(validateQuery(endpoint, query)).toBe(true)
+  })
 })

--- a/src/commands/serve/server/query-validator.ts
+++ b/src/commands/serve/server/query-validator.ts
@@ -6,6 +6,7 @@ const isStringArray = (x: unknown): x is string[] => Array.isArray(x) && typeof 
 
 const compareQuery = (expected: Query[number], actual: Query[number]): boolean => {
   if (typeof expected === 'string') {
+    if (expected === '*') return true
     if (typeof actual === 'string') return expected === actual
     if (isStringArray(actual)) return actual.includes(expected)
     return false


### PR DESCRIPTION
You can allow any value for a query param by using a wildcard

fix #134