### PR TITLE
fix(serve): make typescript a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17373,8 +17373,7 @@
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-      "dev": true
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "typescript-json-schema": {
       "version": "0.42.0",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "semantic-release": "^17.0.7",
     "source-map-support": "^0.5.16",
     "strip-ansi": "^6.0.0",
-    "supertest": "^4.0.2",
-    "typescript": "^3.8.3"
+    "supertest": "^4.0.2"
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
@@ -99,6 +98,7 @@
     "js-yaml": "^3.13.1",
     "node-fetch": "^2.6.0",
     "qs": "^6.9.3",
+    "typescript": "^3.8.3",
     "typescript-json-schema": "^0.42.0",
     "winston": "^3.2.1",
     "yargs": "^15.3.1"


### PR DESCRIPTION
It was only a dev dependency, so isn't available when installing the program

fix #157