### PR TITLE
feat: support using non-json fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "compile": "babel src --out-dir lib --extensions .ts --ignore 'src/**/*.spec.ts','src/**/*.d.ts' --source-maps inline",
     "test": "jest --runInBand --bail",
     "cover": "nyc npm run test -- --coverage --detectOpenHandles",
-    "lint": "eslint '**/*.ts' --color --ignore-path .gitignore --cache",
+    "lint:base": "eslint --color --ignore-path .gitignore --cache",
+    "lint": "npm run lint:base -- '**/*.ts' --fix",
     "semantic-release": "semantic-release"
   },
   "husky": {
@@ -26,7 +27,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "npm run lint -- --fix"
+      "npm run lint:base -- --fix"
     ]
   },
   "config": {

--- a/src/commands/serve/config.ts
+++ b/src/commands/serve/config.ts
@@ -1,5 +1,4 @@
-import { isAbsolute, resolve } from 'path'
-import { readJsonAsync } from '~io'
+import { readFixture } from '~io'
 import { SupportedMethod } from '~config/types'
 
 export interface ValidatedServeConfig {
@@ -27,20 +26,15 @@ export interface ValidatedServeConfig {
 
 export const transformConfigs = async (
   configs: ValidatedServeConfig[],
-  absoluteConfigPath: string,
+  configPath: string,
 ): Promise<ServeConfig[]> => {
-  const loadBody = async (bodyPath: string): Promise<Data | undefined> => {
-    const absolutePathToFile = isAbsolute(bodyPath) ? bodyPath : resolve(absoluteConfigPath, '..', bodyPath)
-    return await readJsonAsync(absolutePathToFile)
-  }
-
   const mapConfig = async (c: ValidatedServeConfig, endpoint: string): Promise<ServeConfig> => {
     let responseBody: Data | undefined
 
     if (c.response.serveBodyPath) {
-      responseBody = await loadBody(c.response.serveBodyPath)
+      responseBody = await readFixture(configPath, c.response.serveBodyPath)
     } else if (c.response.bodyPath) {
-      responseBody = await loadBody(c.response.bodyPath)
+      responseBody = await readFixture(configPath, c.response.bodyPath)
     } else {
       responseBody = c.response.serveBody || c.response.body
     }
@@ -50,7 +44,7 @@ export const transformConfigs = async (
       request: {
         endpoint,
         method: c.request.method,
-        body: c.request.bodyPath ? await loadBody(c.request.bodyPath) : c.request.body,
+        body: c.request.bodyPath ? await readFixture(configPath, c.request.bodyPath) : c.request.body,
         headers: c.request.headers,
         type: c.request.type,
       },

--- a/src/commands/test/config.ts
+++ b/src/commands/test/config.ts
@@ -1,6 +1,5 @@
 import { SupportedMethod, CommonConfig } from '~config/types'
-import { isAbsolute, resolve } from 'path'
-import { readJsonAsync } from '~io'
+import { readFixture } from '~io'
 
 export interface ValidatedTestConfig {
   name: string
@@ -27,13 +26,8 @@ export type TestConfig = CommonConfig
 // TODO: also needs to be responsible for filtering
 export const transformConfigs = async (
   configs: ValidatedTestConfig[],
-  absoluteConfigPath: string,
+  configPath: string,
 ): Promise<TestConfig[]> => {
-  const loadBody = async (bodyPath: string): Promise<Data | undefined> => {
-    const absolutePathToFile = isAbsolute(bodyPath) ? bodyPath : resolve(absoluteConfigPath, '..', bodyPath)
-    return await readJsonAsync(absolutePathToFile)
-  }
-
   return Promise.all(
     configs
       .filter((c) => !c.serveOnly)
@@ -43,13 +37,13 @@ export const transformConfigs = async (
           request: {
             endpoint,
             method: c.request.method,
-            body: c.request.bodyPath ? await loadBody(c.request.bodyPath) : c.request.body,
+            body: c.request.bodyPath ? await readFixture(configPath, c.request.bodyPath) : c.request.body,
             headers: c.request.headers,
             type: c.request.type,
           },
           response: {
             code: c.response.code,
-            body: c.response.bodyPath ? await loadBody(c.response.bodyPath) : c.response.body,
+            body: c.response.bodyPath ? await readFixture(configPath, c.response.bodyPath) : c.response.body,
             headers: c.response.headers,
             type: c.response.type,
           },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@ declare type Public<T> = { [P in keyof T]: T[P] }
 declare type PopulatedArray<T> = { 0: T } & Array<T>
 declare type ROPopulatedArray<T> = { 0: T } & ReadonlyArray<T>
 
-declare type DataObject = { [index: string]: Data }
-declare type Data = string | number | boolean | DataObject | Data[]
+type DataItem = string | number | boolean | null | DataObject | DataItem[]
+type DataObject = { [index: string]: DataItem }
+declare type Data = DataObject | DataObject[] | string
 declare type StringDict = Record<string, string>

--- a/src/io.spec.ts
+++ b/src/io.spec.ts
@@ -1,0 +1,89 @@
+import { readFixture } from '~io'
+import { randomString, mockObj } from '~test-helpers'
+import path from 'path'
+import fs from 'fs'
+
+jest.disableAutomock()
+jest.mock('path')
+jest.mock('fs')
+
+describe('readFixture', () => {
+  const mockedFs = mockObj(fs)
+  const mockedPath = mockObj(path)
+  const basePath = randomString('basePath')
+
+  beforeEach(() => {
+    mockedPath.resolve.mockImplementation((...args) => `${basePath}/${args[2]}`)
+  })
+  afterEach(() => jest.restoreAllMocks())
+
+  it.each([['.json'], ['.txt'], ['.yml'], ['.yaml']])(
+    'calls readFile with the correct args when the path is absolute and the extension is %s',
+    async (extension) => {
+      mockedPath.isAbsolute.mockReturnValue(true)
+      mockedFs.readFile.mockImplementation((path, cb) => {
+        cb(null, Buffer.from(JSON.stringify({ hello: 'world!' })))
+      })
+      const fixturePath = randomString() + extension
+
+      await readFixture(basePath, fixturePath)
+
+      expect(mockedFs.readFile).toBeCalledWith(fixturePath, expect.any(Function))
+    },
+  )
+
+  it.each([['.json'], ['.txt'], ['.yml'], ['.yaml']])(
+    'calls readFile with the correct args when the path is not absolute and the extension is %s',
+    async (extension) => {
+      mockedPath.isAbsolute.mockReturnValue(false)
+      mockedFs.readFile.mockImplementation((path, cb) => {
+        cb(null, Buffer.from(JSON.stringify({ hello: 'world!' })))
+      })
+      const fixturePath = randomString() + extension
+
+      await readFixture(basePath, fixturePath)
+
+      expect(mockedFs.readFile).toBeCalledWith(`${basePath}/${fixturePath}`, expect.any(Function))
+    },
+  )
+
+  it('returns the json when the fixture extension is .json', async () => {
+    const fixturePath = randomString() + '.json'
+    mockedFs.readFile.mockImplementation((path, cb) => {
+      cb(null, Buffer.from(JSON.stringify({ hello: 'world!' })))
+    })
+
+    const result = await readFixture(basePath, fixturePath)
+
+    expect(result).toEqual({
+      hello: 'world!',
+    })
+  })
+
+  it.each([['.yml'], ['.yaml']])(
+    'returns a json version of the document when the extension is %s',
+    async (ext) => {
+      const fixturePath = randomString() + ext
+      mockedFs.readFile.mockImplementation((path, cb) => {
+        cb(null, Buffer.from('goodbye: world'))
+      })
+
+      const result = await readFixture(basePath, fixturePath)
+
+      expect(result).toEqual({
+        goodbye: 'world',
+      })
+    },
+  )
+
+  it('returns plain text when the filepath ends with anything else', async () => {
+    const fixturePath = randomString()
+    mockedFs.readFile.mockImplementation((path, cb) => {
+      cb(null, Buffer.from('goodbye: world'))
+    })
+
+    const result = await readFixture(basePath, fixturePath)
+
+    expect(result).toEqual('goodbye: world')
+  })
+})

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,16 +1,12 @@
 import { readFile } from 'fs'
 import { safeLoad } from 'js-yaml'
+import { isAbsolute, resolve } from 'path'
 
 export const readFileAsync = (path: string): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
-    readFile(path, 'utf8', (err, data) => {
+    readFile(path, (err, data) => {
       if (err) return reject(err)
-
-      try {
-        resolve(data)
-      } catch (err) {
-        reject(err)
-      }
+      resolve(data.toString())
     })
   })
 }
@@ -19,3 +15,10 @@ export const readJsonAsync = async <TOut = object>(path: string): Promise<TOut> 
   JSON.parse(await readFileAsync(path))
 
 export const readYamlAsync = async <TOut>(path: string): Promise<TOut> => safeLoad(await readFileAsync(path))
+
+export const readFixture = (basePath: string, fixturePath: string): Promise<Data> => {
+  const absolutePathToFile = isAbsolute(fixturePath) ? fixturePath : resolve(basePath, '..', fixturePath)
+  if (fixturePath.endsWith('.json')) return readJsonAsync(absolutePathToFile)
+  if (/\.ya?ml$/.test(fixturePath)) return readYamlAsync(absolutePathToFile)
+  return readFileAsync(absolutePathToFile)
+}


### PR DESCRIPTION
Previously, fixtures could only be loaded if they ended with .json and
could be parsed as json. Json files that can't be parsed will still fail,
but now files other than .json can be loaded.

Yaml files will be parsed into JSON, and anything else will be loaded
as plain text.

fix #44