### PR TITLE
fix(serve): validate request bodies in serve mode

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -131,7 +131,11 @@ Here's a format that describes each config setting:
 
 - **Description**: The name of a typescript symbol or a JSON schema file
   (excluding the .json). JSON schema files will only be used if the
-  `--schemaPath` flag is given
+  `--schemaPath` flag is given.<br/>
+  NOTE: This does not yet support using the array syntax in your config file.
+  e.g putting `MyType[]` in your config file will not work. Instead, define a
+  type like `type MyTypeArray = MyType[]` somewhere in your typescript project
+  and use `MyTypeArray` as a type in your config file.
 - **Serve mode**: When a request is sent to ncdc, it will not be served unless
   the body matches the specified type. Additional properties will not cause
   validation to fail.
@@ -166,24 +170,18 @@ Here's a format that describes each config setting:
 
 - **Description**: The body you expect to make requests to the endpoint with.
   Whitespace needs to match exactly.<br>
-  This property cannot be specified at the same time as `request.bodyPath`.<br>
-  In Serve mode, if this property is specified without `request.type`, responses
-  will only be served if the request body matches `request.body` exactly
-  
-  NOTE: This does not yet support using the array syntax in your config file.
-  e.g putting `MyType[]` in your config file will not work. Instead, define a
-  type like `type MyTypeArray = MyType[]` somewhere in your typescript project
-  and use `MyTypeArray` as a type in your config file.
-  
-  <!-- TODO: but are they really? -->
-  The types `number`, `string`, `object`, and `boolean` are recognised by default
-- **Type**: string<br>
+  This property cannot be specified at the same time as `request.bodyPath`.
+- **Serve mode**: Requests will only be served if the request body is deeply
+  equal to the body defined. This behaviour is ignored if `request.type` has
+  been specified.
+- **Test mode**: The request body will be sent to your real API endpoint
+- **Type**: string or object
 - **Required?**: No
-- **Example**: `body: { hello: 'world' }`
+- **Example**:
   ```yaml
   body: Hello world :D
   # or...
-  body: { hello: world }
+  body: { hello: "world" }
   # or...
   body:
     hello: world

--- a/src/commands/serve/server/index.ts
+++ b/src/commands/serve/server/index.ts
@@ -9,6 +9,7 @@ import validateQuery from './query-validator'
 import { SupportedMethod } from '~config/types'
 import { logMetric } from '~metrics'
 import { areHeadersValid } from './header-validator'
+import { isDeeplyEqual } from '~util'
 
 export interface ReqResLog {
   name?: string
@@ -105,6 +106,13 @@ export const configureServer = (
 
             // TODO: something like this to capture better response codes
             // res.locals.status = 400
+            return next()
+          }
+        }
+
+        if (request.body && !request.type) {
+          if (!isDeeplyEqual(request.body, req.body)) {
+            logger.warn(`An endpoint for ${req.path} exists but the request body did not match`)
             return next()
           }
         }

--- a/src/commands/test/test.ts
+++ b/src/commands/test/test.ts
@@ -3,28 +3,11 @@ import { red, green, blue } from 'chalk'
 import { TestConfig } from './config'
 import { inspect } from 'util'
 import { Logger } from 'winston'
+import { isDeeplyEqual } from '~util'
 
 export type LoaderResponse = { status: number; data?: Data }
 export type FetchResource = (config: TestConfig) => Promise<LoaderResponse>
 export type GetTypeValidator = () => TypeValidator
-
-const isDeeplyEqual = (expected: unknown, actual: unknown): boolean => {
-  if (typeof expected === 'object') {
-    if (!expected) return expected === actual
-    if (typeof actual !== 'object') return false
-    if (!actual) return false
-
-    for (const key in expected) {
-      const expectedValue = expected[key as keyof typeof expected]
-      const actualValue = actual[key as keyof typeof actual]
-      if (!isDeeplyEqual(expectedValue, actualValue)) return false
-    }
-
-    return true
-  }
-
-  return expected === actual
-}
 
 export const runTests = async (
   baseUrl: string,

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,0 +1,41 @@
+import { isDeeplyEqual } from '~util'
+
+jest.disableAutomock()
+
+describe('isDeeplyEqual', () => {
+  it('returns true when 2 strings are equal', () => {
+    const str1 = 'hello  world  '
+    const str2 = 'hello  world  '
+
+    const result = isDeeplyEqual(str1, str2)
+
+    expect(result).toBe(true)
+  })
+
+  it('returns false when 2 strings are not equal', () => {
+    const str1 = 'hello  world  '
+    const str2 = 'hello  world'
+
+    const result = isDeeplyEqual(str1, str2)
+
+    expect(result).toBe(false)
+  })
+
+  it('returns true when 2 objects are deeply equal', () => {
+    const obj1 = { hello: ['to', 'the', { world: 'earth' }], cya: 'later', mate: 23 }
+    const obj2 = { hello: ['to', 'the', { world: 'earth' }], cya: 'later', mate: 23 }
+
+    const result = isDeeplyEqual(obj1, obj2)
+
+    expect(result).toBe(true)
+  })
+
+  it('returns false when objects are not deeply equal', () => {
+    const obj1 = { hello: ['to', 'the', { world: 'earth' }], cya: 'later', mate: 23 }
+    const obj2 = { hello: 'world' }
+
+    const result = isDeeplyEqual(obj1, obj2)
+
+    expect(result).toBe(false)
+  })
+})

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,17 @@
+export const isDeeplyEqual = (expected: unknown, actual: unknown): boolean => {
+  if (typeof expected === 'object') {
+    if (!expected) return expected === actual
+    if (typeof actual !== 'object') return false
+    if (!actual) return false
+
+    for (const key in expected) {
+      const expectedValue = expected[key as keyof typeof expected]
+      const actualValue = actual[key as keyof typeof actual]
+      if (!isDeeplyEqual(expectedValue, actualValue)) return false
+    }
+
+    return true
+  }
+
+  return expected === actual
+}


### PR DESCRIPTION
Previously, when serving a request there would be no equality check because the actual request body
and the configured one. Now the check takes place if request.type is ommitted.

fix #5