### PR TITLE
ci(travis): add a post-deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: minimal
+language: node_js
 branches:
   only:
     - master
@@ -9,6 +9,8 @@ jobs:
   include:
     - stage: tests
       before_script:
+        - npm run clean
+        - npm run compile
         - docker-compose build release
         - ci_env=`bash <(curl -s https://codecov.io/env)`
       script:
@@ -16,7 +18,6 @@ jobs:
         - docker-compose run typecheck
         - docker-compose run $ci_env cover
       deploy:
-        install: skip
         provider: script
         skip_cleanup: true
         script:
@@ -26,3 +27,5 @@ jobs:
             - master
             - beta
             - alpha
+      after_deploy:
+        - if ! docker-compose up --build --exit-code-from post-deploy post-deploy; then travis_terminate 1; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,20 @@ RUN apk add --no-cache git
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ENV HUSKY_SKIP_INSTALL=true
+FROM base as setup
+FROM base as post_deploy
 
-FROM base as preinstall
+RUN apk add --no-cache jq
+
 COPY package.json package-lock.json ./
-
+# Necessary because you can't install ncdc inside of ncdc
+RUN cat package.json | jq '.name = "ncdcpostdeploy"' > temp.json && mv temp.json package.json
+RUN cat package-lock.json | jq '.name = "ncdcpostdeploy"' > temp.json && mv temp.json package-lock.json
 RUN npm ci
-COPY . .
 
-RUN npm run compile
+COPY .git ./.git
+COPY install-latest.sh ./
+RUN ./install-latest.sh
+
+COPY tsconfig.json jest.config.js .babelrc ./
+COPY acceptance-tests ./acceptance-tests

--- a/acceptance-tests/wrappers/config-wrapper.ts
+++ b/acceptance-tests/wrappers/config-wrapper.ts
@@ -8,6 +8,7 @@ export const TSCONFIG_FILE = `${TEST_ENV}/tsconfig.json`
 export const JSON_SCHEMAS_FOLDER = `${TEST_ENV}/json-schemas`
 export const FIXTURES_FOLDER = `${TEST_ENV}/fixtures` // TODO: change to fixtures
 export const TYPES_FILE = `${TEST_ENV}/types.ts`
+export const NCDC_EXEC = process.env.NCDC_EXEC ?? './bin/ncdc'
 
 export class ConfigWrapper {
   private configs: Config[] = []

--- a/acceptance-tests/wrappers/generate-wrapper.ts
+++ b/acceptance-tests/wrappers/generate-wrapper.ts
@@ -1,10 +1,10 @@
 import { ChildProcess, exec } from 'child_process'
 import stripAnsi from 'strip-ansi'
-import { NCDC_CONFIG_FILE, JSON_SCHEMAS_FOLDER, TSCONFIG_FILE } from './config-wrapper'
+import { NCDC_CONFIG_FILE, JSON_SCHEMAS_FOLDER, TSCONFIG_FILE, NCDC_EXEC } from './config-wrapper'
 
 export const runGenerateCommand = (): Promise<string> =>
   new Promise<string>((resolve) => {
-    const command = `LOG_LEVEL=debug ./bin/ncdc generate ${NCDC_CONFIG_FILE} --output ${JSON_SCHEMAS_FOLDER} -c ${TSCONFIG_FILE}`
+    const command = `LOG_LEVEL=debug ${NCDC_EXEC} generate ${NCDC_CONFIG_FILE} --output ${JSON_SCHEMAS_FOLDER} -c ${TSCONFIG_FILE}`
     const ncdc: ChildProcess = exec(command)
     const output: string[] = []
     const getRawOutput = (): string => output.join('')

--- a/acceptance-tests/wrappers/serve-wrapper.ts
+++ b/acceptance-tests/wrappers/serve-wrapper.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, exec } from 'child_process'
 import strip from 'strip-ansi'
 import nodeFetch, { RequestInit, Response } from 'node-fetch'
-import { NCDC_CONFIG_FILE, TSCONFIG_FILE } from './config-wrapper'
+import { NCDC_CONFIG_FILE, TSCONFIG_FILE, NCDC_EXEC } from './config-wrapper'
 
 const waitForX = (condition: () => Promise<boolean> | boolean, timeout: number): Promise<void> =>
   new Promise<void>((resolve, reject) => {
@@ -58,7 +58,7 @@ export const prepareServe = (cleanupTasks: CleanupTask[], timeout = 5) => async 
   checkAvailability = true,
 ): Promise<ServeResult> => {
   let hasExited = false
-  const command = `LOG_LEVEL=debug CHOKIDAR_USEPOLLING=1 ./bin/ncdc serve ${NCDC_CONFIG_FILE} -c ${TSCONFIG_FILE} ${args}`
+  const command = `LOG_LEVEL=debug CHOKIDAR_USEPOLLING=1 ${NCDC_EXEC} serve ${NCDC_CONFIG_FILE} -c ${TSCONFIG_FILE} ${args}`
   const ncdc: ChildProcess = exec(command)
   const output: string[] = []
   const getRawOutput = (): string => output.join('\n')

--- a/acceptance-tests/wrappers/test-wrapper.ts
+++ b/acceptance-tests/wrappers/test-wrapper.ts
@@ -2,7 +2,7 @@ import { ChildProcess, exec } from 'child_process'
 import { Server } from 'http'
 import express from 'express'
 import stripAnsi from 'strip-ansi'
-import { NCDC_CONFIG_FILE, TSCONFIG_FILE } from './config-wrapper'
+import { NCDC_CONFIG_FILE, TSCONFIG_FILE, NCDC_EXEC } from './config-wrapper'
 
 export const REAL_SERVER_HOST = 'http://localhost:5000'
 
@@ -13,7 +13,7 @@ export interface TestResult {
 
 export const runTestCommand = (args = ''): Promise<TestResult> =>
   new Promise<TestResult>((resolve) => {
-    const command = `LOG_LEVEL=debug ./bin/ncdc test ${NCDC_CONFIG_FILE} ${REAL_SERVER_HOST} -c ${TSCONFIG_FILE} ${args}`
+    const command = `LOG_LEVEL=debug ${NCDC_EXEC} test ${NCDC_CONFIG_FILE} ${REAL_SERVER_HOST} -c ${TSCONFIG_FILE} ${args}`
     const ncdc: ChildProcess = exec(command)
     const output: string[] = []
     const getOutput = (): string => stripAnsi(output.join(''))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,46 @@
 version: "3.7"
 services:
   lint:
-    build: .
+    build:
+      context: .
+      target: setup
     command: npm run lint
+    volumes:
+      - ./:/usr/src/app
 
   typecheck:
-    build: .
+    build:
+      context: .
+      target: setup
     command: npm run typecheck
+    volumes:
+      - ./:/usr/src/app
 
   # coverage upload only works in CI
   cover:
-    build: .
+    build:
+      context: .
+      target: setup
     command: bash -c 'npm run cover && bash <(curl -s https://codecov.io/bash)'
+    volumes:
+      - ./:/usr/src/app
 
   release:
-    build: .
+    build:
+      context: .
+      target: setup
     environment:
       - GITHUB_TOKEN
       - NPM_TOKEN
     command: npx semantic-release
-
-  watch-acceptance:
-    build:
-      context: .
-      target: base
-    tty: true
-    command: yarn test --watchAll
-    environment:
-      - TEST_MODE=acceptance
     volumes:
       - ./:/usr/src/app
 
-  acceptance:
-    build: .
-    command: bash -c 'yarn compile && yarn test'
+  post-deploy:
+    build:
+      context: .
+      target: post_deploy
+    command: npx jest --runInBand --bail --detectOpenHandles
     environment:
       - TEST_MODE=acceptance
+      - NCDC_EXEC=./node_modules/.bin/ncdc

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+GREEN='\033[1;32m'
+RED='\033[1;31m'
+BLUE='\033[1;34m'
+
+print() {
+  echo -e "${2:-$BLUE}== $1 ==\033[0m"
+}
+
+function finish {
+  if [ $? -ne 0 ];
+  then
+    print 'ncdc install failed' $RED
+  else
+    print 'ncdc install complete' $GREEN
+  fi
+}
+trap finish EXIT
+
+print 'getting latest ncdc tag'
+NCDC_VERSION=$(git describe --abbrev=0 --tags)
+
+print "installing ncdc $NCDC_VERSION"
+npm i ncdc@$NCDC_VERSION


### PR DESCRIPTION
The purpose will be to run the test suite again against the version of ncdc published on npm