### PR TITLE
fix(serve): fix wildcard queries false positives

### DIFF
--- a/src/commands/serve/server/query-validator.spec.ts
+++ b/src/commands/serve/server/query-validator.spec.ts
@@ -100,6 +100,13 @@ describe('wildcard queries', () => {
     expect(validateQuery(endpoint, query)).toBe(true)
   })
 
+  it('returns false if an expected value is undefined', () => {
+    const endpoint = '/api/resource?hello=*'
+    const query = {}
+
+    expect(validateQuery(endpoint, query)).toBe(false)
+  })
+
   it('returns true for an array of any values', () => {
     const endpoint = '/api/resource?hello=*'
     const query = { hello: [randomString(), randomString()] }

--- a/src/commands/serve/server/query-validator.ts
+++ b/src/commands/serve/server/query-validator.ts
@@ -6,9 +6,15 @@ const isStringArray = (x: unknown): x is string[] => Array.isArray(x) && typeof 
 
 const compareQuery = (expected: Query[number], actual: Query[number]): boolean => {
   if (typeof expected === 'string') {
-    if (expected === '*') return true
-    if (typeof actual === 'string') return expected === actual
-    if (isStringArray(actual)) return actual.includes(expected)
+    if (typeof actual === 'string') {
+      if (expected === '*' && actual !== undefined) return true
+      return expected === actual
+    }
+
+    if (isStringArray(actual)) {
+      return expected === '*' || actual.includes(expected)
+    }
+
     return false
   }
 


### PR DESCRIPTION
When a wildcard was used for a query param, it would match even if that query param was undefined

fix #211