### PR TITLE
feat(generate): improve metrics around schema generation

### DIFF
--- a/src/commands/generate/command.ts
+++ b/src/commands/generate/command.ts
@@ -6,6 +6,7 @@ import { readGenerateConfig } from './config'
 import { SchemaGenerator } from '~schema'
 import { generate } from './generate'
 import logger from '~logger'
+import { logMetric } from '~metrics'
 
 const builder = (yargs: Argv): Argv<GenerateArgs> =>
   yargs
@@ -23,6 +24,7 @@ const builder = (yargs: Argv): Argv<GenerateArgs> =>
 export default function createGenerateCommand(): CommandModule<{}, GenerateArgs> {
   const handleError: HandleError = ({ message }) => {
     logger.error(message)
+    logMetric('Sad ending')
     process.exit(1)
   }
 

--- a/src/commands/generate/handler.ts
+++ b/src/commands/generate/handler.ts
@@ -4,6 +4,7 @@ import { SchemaRetriever } from '~schema'
 import { Generate } from './generate'
 import { Logger } from 'winston'
 import { resolve } from 'path'
+import { logMetric } from '~metrics'
 
 export interface GenerateArgs {
   configPath?: string
@@ -56,6 +57,8 @@ const createHandler = (
   } finally {
     logger.info('JSON schemas have been written to disk')
   }
+
+  logMetric('Happy ending')
 }
 
 export default createHandler

--- a/src/commands/serve/handler.ts
+++ b/src/commands/serve/handler.ts
@@ -7,7 +7,6 @@ import chokidar from 'chokidar'
 import { StartServerResult } from './server'
 import { LoadConfig, LoadConfigStatus } from '~config/load'
 import { red } from 'chalk'
-import { logMetric } from '~metrics'
 import { Logger } from './server/server-logger'
 
 export interface ServeArgs {
@@ -46,7 +45,6 @@ const createHandler = (
   loadConfig: LoadConfig<ValidatedServeConfig>,
   getServerLogger: (verbose: boolean) => Logger,
 ) => async (args: ServeArgs): Promise<void> => {
-  logMetric('Program start')
   const { configPath, port, tsconfigPath, schemaPath, force, watch, verbose } = args
 
   if (!configPath) return handleError({ message: 'config path must be supplied' })

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -35,7 +35,7 @@ const builder = (yargs: Argv): Argv<ServeArgs> =>
 export default function createServeCommand() {
   const handleError: HandleError = ({ message }) => {
     logger.error(message)
-    logMetric('Errored out')
+    logMetric('Sad ending')
     process.exit(1)
   }
 

--- a/src/commands/serve/server/index.ts
+++ b/src/commands/serve/server/index.ts
@@ -178,8 +178,8 @@ export const startServer = (
   const app = configureServer(serverRoot, routes, typeValidator, logger)
 
   const server = app.listen(port, () => {
+    logMetric('Server listening')
     logger.info(`Endpoints are being served on ${serverRoot}`)
-    logMetric('Server is listening')
   })
 
   return {

--- a/src/commands/test/command.ts
+++ b/src/commands/test/command.ts
@@ -9,6 +9,7 @@ import { FsSchemaLoader, SchemaRetriever } from '~schema'
 import { SchemaGenerator } from '~schema'
 import ajv from 'ajv'
 import { TypeValidator } from '~validation'
+import { logMetric } from '~metrics'
 
 const builder = (yargs: Argv): Argv<TestArgs> =>
   yargs
@@ -25,6 +26,7 @@ const builder = (yargs: Argv): Argv<TestArgs> =>
 export default function createTestCommand(): CommandModule<{}, TestArgs> {
   const handleError: HandleError = ({ message }) => {
     logger.error(message)
+    logMetric('Sad ending')
     process.exit(1)
   }
 

--- a/src/commands/test/handler.ts
+++ b/src/commands/test/handler.ts
@@ -6,7 +6,7 @@ import { LoadConfig, LoadConfigStatus, GetTypeValidator } from '~config/load'
 import { ValidatedTestConfig, transformConfigs } from './config'
 import { red } from 'chalk'
 import { TypeValidator } from '~validation'
-import { inspect } from 'util'
+import { logMetric } from '~metrics'
 
 export interface TestArgs {
   schemaPath?: string
@@ -46,7 +46,6 @@ export const createHandler = (
     case LoadConfigStatus.NoConfigs:
       return handleError({ message: red('No configs to test') })
     default:
-      logger.debug(inspect(loadResult))
       return handleError({ message: 'An unknown error ocurred' })
   }
 
@@ -58,4 +57,6 @@ export const createHandler = (
     logger,
   )
   if (testResult === 'Failure') return handleError({ message: 'Not all tests passed' })
+
+  logMetric('Happy ending')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import mainYargs from 'yargs'
 import { createGenerateCommand, createServeCommand, createTestCommand } from './commands'
 import { opts } from './commands'
+import { logMetric } from '~metrics'
 
 export default function run(): void {
+  logMetric('Program started')
+
   // TODO: figure out how I can remove this
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   mainYargs

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,5 @@
 import logger from '~logger'
+import { blue, red, green } from 'chalk'
 
 let startTime: Date
 let previousMetricTime: Date
@@ -6,17 +7,39 @@ let previousMetricTime: Date
 const calcDiff = (startTime: Date, endTime: Date): number =>
   Math.round(endTime.getTime() - startTime.getTime()) / 1000
 
-export const logMetric = (message: string): void => {
+export enum MetricState {
+  Started = 'started',
+  Failed = 'failed',
+  Completed = 'completed',
+}
+
+const getMessage = (action: string, state?: MetricState): string => {
+  if (!state) return action
+
+  switch (state) {
+    case MetricState.Started:
+      return `${action} - ${blue(state)}`
+    case MetricState.Failed:
+      return `${action} - ${red(state)}`
+    case MetricState.Completed:
+      return `${action} - ${green(state)}`
+  }
+}
+
+export const logMetric = (action: string, state?: MetricState): void => {
   if (!startTime) {
     startTime = new Date()
     previousMetricTime = startTime
-    logger.debug(`Metric | ${message}`)
+    logger.debug(`Metric: ${action}`)
     return
   }
 
   const timeNow = new Date()
-  const timeDiff = calcDiff(previousMetricTime, timeNow)
-  const elapsedDiff = calcDiff(startTime, timeNow)
-  logger.debug(`Metric | ${message} | diff: ${timeDiff} | full diff: ${elapsedDiff}`)
+  const timeDiff = blue(calcDiff(previousMetricTime, timeNow) + 's')
+  const elapsedDiff = blue(calcDiff(startTime, timeNow) + 's')
+
+  logger.debug(
+    `Metric: ${getMessage(action, state)} | time passed: ${timeDiff} | time since start: ${elapsedDiff}`,
+  )
   previousMetricTime = timeNow
 }

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -1,38 +1,77 @@
 import { SchemaRetriever } from './types'
 import ts from 'typescript'
 import { JsonSchemaGenerator, buildGenerator, Definition } from 'typescript-json-schema'
-import { readTsConfig } from './ts-helpers'
+import { readTsConfig, formatErrorDiagnostic } from './ts-helpers'
+import { logMetric, MetricState } from '~metrics'
 
 export class SchemaGenerator implements SchemaRetriever {
   private readonly cache = new Map<string, Definition>()
   private generator?: JsonSchemaGenerator
 
-  // TODO: constructors probably shouldn't have side effects like these
-  constructor(private readonly pathOrProgram: string | ts.Program, private readonly force = false) {}
+  private readonly programMetric = 'build a typescript program'
+  private readonly generateMetric = 'build a schema generator'
+
+  constructor(
+    private readonly pathOrProgram: string | ts.Program,
+    private readonly skipTypeChecking = false,
+  ) {}
 
   public init(): void {
-    let program: ts.Program
-    if (typeof this.pathOrProgram === 'string') {
-      const configFile = readTsConfig(this.pathOrProgram)
-      program = ts.createProgram({ rootNames: configFile.fileNames, options: configFile.options })
-    } else {
-      program = this.pathOrProgram
-    }
+    const program = this.getTsProgram()
 
-    const generator = buildGenerator(program, { required: true, ignoreErrors: this.force })
-    if (!generator) throw new Error('Could not build a generator from the given typescript configuration')
+    logMetric(this.generateMetric, MetricState.Started)
+    const generator = buildGenerator(program, { required: true, ignoreErrors: true })
+    if (!generator) {
+      logMetric(this.generateMetric, MetricState.Failed)
+      throw new Error('Could not build a generator from the given typescript configuration')
+    }
+    logMetric(this.generateMetric, MetricState.Completed)
     this.generator = generator
   }
 
   public async load(symbolName: string): Promise<Definition> {
+    this.reportLoadMetric(symbolName, MetricState.Started)
     let schema = this.cache.get(symbolName)
 
     if (!schema) {
-      if (!this.generator) throw new Error('No schema generator has been initialised')
-      schema = this.generator.getSchemaForSymbol(symbolName)
+      if (!this.generator) {
+        this.reportLoadMetric(symbolName, MetricState.Failed)
+        throw new Error('No schema generator has been initialised')
+      }
+
+      try {
+        schema = this.generator.getSchemaForSymbol(symbolName)
+      } catch (err) {
+        this.reportLoadMetric(symbolName, MetricState.Failed)
+        throw err
+      }
+
       this.cache.set(symbolName, schema)
     }
 
+    this.reportLoadMetric(symbolName, MetricState.Completed)
     return Promise.resolve(schema)
+  }
+
+  private getTsProgram(): ts.Program {
+    if (typeof this.pathOrProgram !== 'string') return this.pathOrProgram
+    logMetric(this.programMetric, MetricState.Started)
+    const configFile = readTsConfig(this.pathOrProgram)
+    const program = ts.createProgram({ rootNames: configFile.fileNames, options: configFile.options })
+
+    if (!this.skipTypeChecking) {
+      const diagnostics = ts.getPreEmitDiagnostics(program)
+      if (diagnostics.length) {
+        logMetric(this.programMetric, MetricState.Failed)
+        throw new Error(diagnostics.map(formatErrorDiagnostic).join('\n'))
+      }
+    }
+
+    logMetric(this.programMetric, MetricState.Completed)
+    return program
+  }
+
+  private reportLoadMetric = (name: string, state: MetricState): void => {
+    logMetric(`load schema for ${name}`, state)
   }
 }


### PR DESCRIPTION
You can now get some decent metrics about the time it takes for certain
operations to run by using LOG_LEVEL=debug environment variable

fix #229