### PR TITLE
ci(github actions): use ci env for release container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Release
         if: ${{ github.event_name != 'pull_request' }}
-        run: docker-compose run release
+        run: docker-compose run "$(bash <(curl -s https://codecov.io/env))" release
         env:
           GITHUB_TOKEN: ${{ secrets.NCDC_GITHUB_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes semantic release not releasing due to not being able to detect the CI environment